### PR TITLE
feat: Prevent rendering with no pages

### DIFF
--- a/components/ui/pagination-with-links.tsx
+++ b/components/ui/pagination-with-links.tsx
@@ -60,6 +60,7 @@ export function PaginationWithLinks({
   pageSearchParam,
   navigationMode = "link",
 }: PaginationWithLinksProps) {
+  if (totalCount <= pageSize) return null
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();


### PR DESCRIPTION
Disabled rendering the component, if there are no pages to display, instead of displaying just one page with useless Previous / Next links.